### PR TITLE
Implement Single Instance Lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.vs

--- a/electron/src/main/app.ts
+++ b/electron/src/main/app.ts
@@ -7,80 +7,98 @@ import { ChangeSwitchAction, EnsureInGameAction, InjectDLLAction, ReadAddressAct
 import { AttachTask, AutosaveTask, LoggerTask, OverlayTask, ReadWorldTask } from './tasks';
 import { AutosaveIPCListener, ChangeSwitchIPCListener, GetAttachedStateIPCHandler, KillDanglingInjector, MapDataIPCHandler, SetAttachedStateIPCListener, SetEngineControlsIPCListener, UpdateConfigIPCListener } from './ipc';
 
-/** Handle creating/removing shortcuts on Windows when installing/uninstalling. */
-if ( require( 'electron-squirrel-startup' ) ) {
+const singleInstanceLock = app.requestSingleInstanceLock();
+
+if (!singleInstanceLock) {
     app.quit();
-}
-
-Updater( {
-    logger    : Logger,
-    notifyUser: false, // We manually notify the user with a custom message
-} );
-
-autoUpdater.on( 'update-downloaded', ( event, releaseNotes, releaseName, releaseDate, updateURL ) => {
-    Logger.log( 'update-downloaded', [ event, releaseNotes, releaseName, releaseDate, updateURL ] )
-
-    const dialogOpts = {
-        type: 'info',
-        buttons: [ 'Restart', 'Later' ],
-        title: 'Application Update',
-        message: process.platform === 'win32' ? releaseNotes : releaseName,
-        detail: 'A new version is available. Before updating, please shut down the game, if it is running.'
+} else {
+    /** Handle creating/removing shortcuts on Windows when installing/uninstalling. */
+    if ( require( 'electron-squirrel-startup' ) ) {
+        app.quit();
     }
 
-    dialog.showMessageBox( dialogOpts ).then( ( { response } ) => {
-        if ( response === 0 ) autoUpdater.quitAndInstall()
-    } )
-} );
+    Updater( {
+        logger    : Logger,
+        notifyUser: false, // We manually notify the user with a custom message
+    } );
 
-app.on( 'ready', async () => {
-    let rrox = new RROx();
+    autoUpdater.on( 'update-downloaded', ( event, releaseNotes, releaseName, releaseDate, updateURL ) => {
+        Logger.log( 'update-downloaded', [ event, releaseNotes, releaseName, releaseDate, updateURL ] )
 
-    rrox.addWindow( WindowType.App    , createAppWindow    () );
-    rrox.addWindow( WindowType.Overlay, createOverlayWindow() );
+        const dialogOpts = {
+            type: 'info',
+            buttons: [ 'Restart', 'Later' ],
+            title: 'Application Update',
+            message: process.platform === 'win32' ? releaseNotes : releaseName,
+            detail: 'A new version is available. Before updating, please shut down the game, if it is running.'
+        }
 
-    // Initialize all actions
-    const actions = [
-        ChangeSwitchAction,
-        EnsureInGameAction,
-        InjectDLLAction,
-        ReadAddressAction,
-        ReadAddressValueAction,
-        ReadWorldAction,
-        SaveAction,
-        SetEngineControlsAction,
-        StopAction
-    ];
-    rrox.createActions( actions );
+        dialog.showMessageBox( dialogOpts ).then( ( { response } ) => {
+            if ( response === 0 ) autoUpdater.quitAndInstall()
+        } )
+    } );
 
-    // Initialize all tasks and autostart all (except for attach)
-    const tasks = [
-        AttachTask,
-        AutosaveTask,
-        ReadWorldTask,
-        LoggerTask,
-        OverlayTask
-    ];
-    rrox.createTasks( tasks );
-    await rrox.startTasks( tasks.filter( ( t ) => t !== AttachTask ) );
+    let rrox: RROx;
+    app.on( 'ready', async () => {
+        rrox = new RROx();
 
-    // Initialize and start all IPC tasks
-    const ipc = [
-        AutosaveIPCListener,
-        ChangeSwitchIPCListener,
-        GetAttachedStateIPCHandler,
-        KillDanglingInjector,
-        MapDataIPCHandler,
-        SetAttachedStateIPCListener,
-        SetEngineControlsIPCListener,
-        UpdateConfigIPCListener
-    ];
-    rrox.createTasks( ipc );
-    await rrox.startTasks( ipc );
+        rrox.addWindow( WindowType.App    , createAppWindow    () );
+        rrox.addWindow( WindowType.Overlay, createOverlayWindow() );
 
-    rrox.start();
-} );
+        // Initialize all actions
+        const actions = [
+            ChangeSwitchAction,
+            EnsureInGameAction,
+            InjectDLLAction,
+            ReadAddressAction,
+            ReadAddressValueAction,
+            ReadWorldAction,
+            SaveAction,
+            SetEngineControlsAction,
+            StopAction
+        ];
+        rrox.createActions( actions );
 
-app.on( 'window-all-closed', () => {
-    app.quit();
-} );
+        // Initialize all tasks and autostart all (except for attach)
+        const tasks = [
+            AttachTask,
+            AutosaveTask,
+            ReadWorldTask,
+            LoggerTask,
+            OverlayTask
+        ];
+        rrox.createTasks( tasks );
+        await rrox.startTasks( tasks.filter( ( t ) => t !== AttachTask ) );
+
+        // Initialize and start all IPC tasks
+        const ipc = [
+            AutosaveIPCListener,
+            ChangeSwitchIPCListener,
+            GetAttachedStateIPCHandler,
+            KillDanglingInjector,
+            MapDataIPCHandler,
+            SetAttachedStateIPCListener,
+            SetEngineControlsIPCListener,
+            UpdateConfigIPCListener
+        ];
+        rrox.createTasks( ipc );
+        await rrox.startTasks( ipc );
+
+        rrox.start();
+    } );
+
+    app.on( 'second-instance', () => {
+        let window = rrox?.getWindow(WindowType.App);
+        if (window) {
+            if (window.isMinimized()) {
+                window.restore();
+            }
+
+            window.focus();
+        }
+    });
+
+    app.on( 'window-all-closed', () => {
+        app.quit();
+    } );
+}


### PR DESCRIPTION
Prevents a second instance of RROx from running.  If second instance start is attempted, the original instance will be brought into focus.